### PR TITLE
update project name in GitHub url setup arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.2.0b1',
     author='Tomasz Jakub Rup',
     author_email='tomasz.rup@gmail.com',
-    url='https://github.com/tomi77/django_extra_tools',
+    url='https://github.com/tomi77/django-extra-tools',
     description='A set of functions related with Django',
     long_description=open("README.rst").read(),
     classifiers=[


### PR DESCRIPTION
s/django_extra_tools/django-extra-tools/

It's a tiny change but it fixes the link from PyPI to the repository. If you don't like small commits in your git history, feel free to ignore this PR and just fix it whenever you next update setup. 😄 

Thanks for sharing your code! 